### PR TITLE
Add .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+node-modules


### PR DESCRIPTION
I am running `npm install` to locally test the package. But that results in the generation of `package-lock.json` and `node-modules` folder. So, I am adding the `.gitignore` file to prevent git from tracking it. 