### PR TITLE
Bump Package Version To 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphina",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "A small graph library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I am trying to publicly publish the `graphina` package. But `npm` complains that it will not allow me to publish me a new package if the package version is not updated. So, I am bumping the package minor version to allow for the package to be published on npm. 