### PR TITLE
Bump Package To 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphina",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A small graph library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I fixed all the incorrect links to `graphitas` in the package.json file in this PR - https://github.com/adhithyan15/graphina/pull/5. But npm picked up the incorrect links from the old package.json. So, I need to push another package update to fix it. 