### PR TITLE
Add Webpack As Dev Dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 package-lock.json
-node-modules
+node_modules/

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "bugs": {
     "url": "https://github.com/adhithyan15/graphina/issues"
   },
-  "homepage": "https://github.com/adhithyan15/graphina#readme"
+  "homepage": "https://github.com/adhithyan15/graphina#readme",
+  "devDependencies": {
+    "webpack": "^5.37.1",
+    "webpack-cli": "^4.7.0"
+  }
 }


### PR DESCRIPTION
I will be using `webpack` to build the library. So, adding it as a dev dependency. I made a typo in the `.gitignore` that prevented node_modules from being ignored. So, fixing that as well. 